### PR TITLE
Implement json.Marshaler for Variant and Signature

### DIFF
--- a/sig.go
+++ b/sig.go
@@ -1,6 +1,7 @@
 package dbus
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -256,4 +257,8 @@ func typeFor(s string) (t reflect.Type) {
 		t = interfacesType
 	}
 	return
+}
+
+func (s Signature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.str)
 }

--- a/variant.go
+++ b/variant.go
@@ -2,6 +2,7 @@ package dbus
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -141,4 +142,16 @@ func (v Variant) String() string {
 // Value returns the underlying value of v.
 func (v Variant) Value() interface{} {
 	return v.value
+}
+
+type VariantJSONMarshal struct {
+	Sig   Signature
+	Value interface{}
+}
+
+func (v Variant) MarshalJSON() ([]byte, error) {
+	return json.Marshal(VariantJSONMarshal{
+		Sig:   v.sig,
+		Value: v.value,
+	})
 }


### PR DESCRIPTION
Implement json.Marshaler to make debugging a bit easier. The output of something like `json.MarshalIndent(map[dbus.ObjectPath]map[string]map[string]dbus.Variant)` now looks like this:

```
 {
    "/org/freedesktop/ModemManager1/Modem/4": {
      "org.freedesktop.ModemManager1.Modem": {
        "AccessTechnologies": {
          "Sig": "u",
          "Value": 0
        },
        "Bearers": {
          "Sig": "ao",
          "Value": []
        },
        "CurrentBands": {
          "Sig": "au",
          "Value": [
            0
          ]
        },
        "CurrentCapabilities": {
          "Sig": "u",
          "Value": 4
        },
        "CurrentModes": {
          "Sig": "av",
          "Value": [
            4294967295,
            0
          ]
        },
        "Device": {
          "Sig": "s",
          "Value": "/sys/devices/pci0000:00/0000:00:14.0/usb1/1-2"
        },
...
```