### PR TITLE
Recursively call store if src type is dbus.Variant

### DIFF
--- a/dbus.go
+++ b/dbus.go
@@ -87,10 +87,15 @@ func setDest(dest, src reflect.Value) error {
 	}
 	if isVariant(src.Type()) && !isVariant(dest.Type()) {
 		src = getVariantValue(src)
+		// not quite ready to directly convert,
+		// since we're dealing with a variant value
+		// which may have a complex type
+		return store(dest, src)
 	}
+
 	if !src.Type().ConvertibleTo(dest.Type()) {
 		return fmt.Errorf(
-			"dbus.Store: type mismatch: cannot convert %s to %s",
+			"dbus.Store: base type mismatch: cannot convert %s to %s",
 			src.Type(), dest.Type())
 	}
 	dest.Set(src.Convert(dest.Type()))

--- a/store_test.go
+++ b/store_test.go
@@ -97,3 +97,26 @@ func TestStoreNested(t *testing.T) {
 			dest, src)
 	}
 }
+
+type testStruct1 struct {
+	V0 uint32
+	V1 bool
+}
+
+func TestStoreVariantStruct(t *testing.T) {
+	src := MakeVariantWithSignature([]interface{}{1, true}, Signature{"(ub)"})
+	dest := testStruct1{}
+	err := Store([]interface{}{src}, &dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dest.V0, uint32(1)) {
+		t.Errorf("not equal: got '%v', want '%v'",
+			dest.V0, 1)
+	}
+	if !reflect.DeepEqual(dest.V1, true) {
+		t.Errorf("not equal: got '%v', want '%v'",
+			dest.V1, true)
+	}
+
+}


### PR DESCRIPTION
Before this change the code in `setDest` assumed that all variant types could have the destination value set to their internal Value. This is not the case for a number of dbus objects. We ran into this issue when attempting to call store on a dbus object which has the signature `(ub)`. In this case we needed another pass through the root-level `store` function to convert the dbus variant's underlying `[]interface{}` value to the appropriate struct value `struct { uint32; bool; }`

Still writing a test for this. 